### PR TITLE
Automatic update of GitVersion.Tool to 5.6.6

### DIFF
--- a/SharpBoard.Build/SharpBoard.Build.csproj
+++ b/SharpBoard.Build/SharpBoard.Build.csproj
@@ -1,5 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
@@ -8,15 +8,12 @@
     <NukeRootDirectory>..</NukeRootDirectory>
     <NukeScriptDirectory>..</NukeScriptDirectory>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Nuke.Common" Version="5.0.2" />
   </ItemGroup>
-
   <ItemGroup>
     <PackageDownload Include="dotnet-sonarscanner" Version="[5.0.4]" />
     <PackageDownload Include="dotnet-format" Version="[5.0.211103]" />
-    <PackageDownload Include="GitVersion.Tool" Version="[5.5.1]" />
+    <PackageDownload Include="GitVersion.Tool" Version="[5.6.6]" />
   </ItemGroup>
-
 </Project>


### PR DESCRIPTION
NuKeeper has generated a minor update of `GitVersion.Tool` to `5.6.6` from `5.5.1`
`GitVersion.Tool 5.6.6` was published at `2021-02-08T13:03:31Z`, 25 days ago

1 project update:
Updated `SharpBoard.Build\SharpBoard.Build.csproj` to `GitVersion.Tool` `5.6.6` from `5.5.1`

[GitVersion.Tool 5.6.6 on NuGet.org](https://www.nuget.org/packages/GitVersion.Tool/5.6.6)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
