### PR TITLE
Automatic update of Serilog.Extensions.Hosting to 4.1.2

### DIFF
--- a/SharpBoard.Desktop/SharpBoard.Desktop.csproj
+++ b/SharpBoard.Desktop/SharpBoard.Desktop.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
     <PackageReference Include="morelinq" Version="3.3.2" />
     <PackageReference Include="Serilog" Version="2.10.0" />
-    <PackageReference Include="Serilog.Extensions.Hosting" Version="4.1.0" />
+    <PackageReference Include="Serilog.Extensions.Hosting" Version="4.1.2" />
     <PackageReference Include="Serilog.Sinks.Debug" Version="2.0.0" />
     <PackageReference Include="TesoroRgb.Core" Version="1.0.0" />
   </ItemGroup>


### PR DESCRIPTION
NuKeeper has generated a patch update of `Serilog.Extensions.Hosting` to `4.1.2` from `4.1.0`
`Serilog.Extensions.Hosting 4.1.2` was published at `2021-03-03T06:27:14Z`, 2 days ago

1 project update:
Updated `SharpBoard.Desktop\SharpBoard.Desktop.csproj` to `Serilog.Extensions.Hosting` `4.1.2` from `4.1.0`

[Serilog.Extensions.Hosting 4.1.2 on NuGet.org](https://www.nuget.org/packages/Serilog.Extensions.Hosting/4.1.2)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
