### PR TITLE
Automatic update of 2 packages

### DIFF
--- a/SharpBoard.Build/SharpBoard.Build.csproj
+++ b/SharpBoard.Build/SharpBoard.Build.csproj
@@ -1,5 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
@@ -8,15 +8,12 @@
     <NukeRootDirectory>..</NukeRootDirectory>
     <NukeScriptDirectory>..</NukeScriptDirectory>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Nuke.Common" Version="5.0.2" />
   </ItemGroup>
-
   <ItemGroup>
     <PackageDownload Include="dotnet-sonarscanner" Version="[5.0.4]" />
     <PackageDownload Include="dotnet-format" Version="[5.0.211103]" />
-    <PackageDownload Include="GitVersion.Tool" Version="[5.5.1]" />
+    <PackageDownload Include="GitVersion.Tool" Version="[5.6.6]" />
   </ItemGroup>
-
 </Project>

--- a/SharpBoard.Desktop/SharpBoard.Desktop.csproj
+++ b/SharpBoard.Desktop/SharpBoard.Desktop.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
     <PackageReference Include="morelinq" Version="3.3.2" />
     <PackageReference Include="Serilog" Version="2.10.0" />
-    <PackageReference Include="Serilog.Extensions.Hosting" Version="4.1.0" />
+    <PackageReference Include="Serilog.Extensions.Hosting" Version="4.1.2" />
     <PackageReference Include="Serilog.Sinks.Debug" Version="2.0.0" />
     <PackageReference Include="TesoroRgb.Core" Version="1.0.0" />
   </ItemGroup>


### PR DESCRIPTION
2 packages were updated in 2 projects:
`GitVersion.Tool`, `Serilog.Extensions.Hosting`
<details>
<summary>Details of updated packages</summary>

NuKeeper has generated a minor update of `GitVersion.Tool` to `5.6.6` from `5.5.1`
`GitVersion.Tool 5.6.6` was published at `2021-02-08T13:03:31Z`, 25 days ago

1 project update:
Updated `SharpBoard.Build\SharpBoard.Build.csproj` to `GitVersion.Tool` `5.6.6` from `5.5.1`

[GitVersion.Tool 5.6.6 on NuGet.org](https://www.nuget.org/packages/GitVersion.Tool/5.6.6)

NuKeeper has generated a patch update of `Serilog.Extensions.Hosting` to `4.1.2` from `4.1.0`
`Serilog.Extensions.Hosting 4.1.2` was published at `2021-03-03T06:27:14Z`, 2 days ago

1 project update:
Updated `SharpBoard.Desktop\SharpBoard.Desktop.csproj` to `Serilog.Extensions.Hosting` `4.1.2` from `4.1.0`

[Serilog.Extensions.Hosting 4.1.2 on NuGet.org](https://www.nuget.org/packages/Serilog.Extensions.Hosting/4.1.2)

</details>


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
