### PR TITLE
Automatic update of dotnet-sonarscanner to 5.1.0

### DIFF
--- a/SharpBoard.Build/SharpBoard.Build.csproj
+++ b/SharpBoard.Build/SharpBoard.Build.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Nuke.Common" Version="5.0.2" />
   </ItemGroup>
   <ItemGroup>
-    <PackageDownload Include="dotnet-sonarscanner" Version="[5.0.4]" />
+    <PackageDownload Include="dotnet-sonarscanner" Version="[5.1.0]" />
     <PackageDownload Include="dotnet-format" Version="[5.0.211103]" />
     <PackageDownload Include="GitVersion.Tool" Version="[5.6.6]" />
     <PackageDownload Include="nukeeper" Version="[0.34.0]" />


### PR DESCRIPTION
NuKeeper has generated a minor update of `dotnet-sonarscanner` to `5.1.0` from `5.0.4`
`dotnet-sonarscanner 5.1.0` was published at `2021-03-08T07:35:22Z`, 22 hours ago

1 project update:
Updated `SharpBoard.Build\SharpBoard.Build.csproj` to `dotnet-sonarscanner` `5.1.0` from `5.0.4`

[dotnet-sonarscanner 5.1.0 on NuGet.org](https://www.nuget.org/packages/dotnet-sonarscanner/5.1.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
