### PR TITLE
Automatic update of Ardalis.SmartEnum to 2.0.1

### DIFF
--- a/SharpBoard/SharpBoard.csproj
+++ b/SharpBoard/SharpBoard.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Ardalis.SmartEnum" Version="2.0.0" />
+    <PackageReference Include="Ardalis.SmartEnum" Version="2.0.1" />
     <PackageReference Include="MediatR" Version="9.0.0" />
     <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0" />


### PR DESCRIPTION
NuKeeper has generated a patch update of `Ardalis.SmartEnum` to `2.0.1` from `2.0.0`
`Ardalis.SmartEnum 2.0.1` was published at `2021-03-12T20:22:25Z`, 9 hours ago

1 project update:
Updated `SharpBoard\SharpBoard.csproj` to `Ardalis.SmartEnum` `2.0.1` from `2.0.0`

[Ardalis.SmartEnum 2.0.1 on NuGet.org](https://www.nuget.org/packages/Ardalis.SmartEnum/2.0.1)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
