### PR TITLE
Automatic update of SonarAnalyzer.CSharp to 8.20.0.28934

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,13 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project>
-
   <PropertyGroup>
     <LangVersion>9.0</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>
-
   <ItemGroup>
-    <PackageReference Include="Roslynator.Analyzers" Version="3.1.0" PrivateAssets="all"/>
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.19.0.28253" PrivateAssets="all"/>
+    <PackageReference Include="Roslynator.Analyzers" Version="3.1.0" PrivateAssets="all" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.20.0.28934" PrivateAssets="all" />
   </ItemGroup>
-
 </Project>


### PR DESCRIPTION
NuKeeper has generated a minor update of `SonarAnalyzer.CSharp` to `8.20.0.28934` from `8.19.0.28253`
`SonarAnalyzer.CSharp 8.20.0.28934` was published at `2021-03-17T10:45:19Z`, 19 hours ago

1 project update:
Updated `Directory.Build.props` to `SonarAnalyzer.CSharp` `8.20.0.28934` from `8.19.0.28253`

[SonarAnalyzer.CSharp 8.20.0.28934 on NuGet.org](https://www.nuget.org/packages/SonarAnalyzer.CSharp/8.20.0.28934)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
