### PR TITLE
Automatic update of GitVersion.Tool to 5.6.7

### DIFF
--- a/SharpBoard.Build/SharpBoard.Build.csproj
+++ b/SharpBoard.Build/SharpBoard.Build.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageDownload Include="dotnet-sonarscanner" Version="[5.1.0]" />
     <PackageDownload Include="dotnet-format" Version="[5.0.211103]" />
-    <PackageDownload Include="GitVersion.Tool" Version="[5.6.6]" />
+    <PackageDownload Include="GitVersion.Tool" Version="[5.6.7]" />
     <PackageDownload Include="nukeeper" Version="[0.34.0]" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
NuKeeper has generated a patch update of `GitVersion.Tool` to `5.6.7` from `5.6.6`
`GitVersion.Tool 5.6.7` was published at `2021-03-25T13:57:26Z`, 16 hours ago

1 project update:
Updated `SharpBoard.Build\SharpBoard.Build.csproj` to `GitVersion.Tool` `5.6.7` from `5.6.6`

[GitVersion.Tool 5.6.7 on NuGet.org](https://www.nuget.org/packages/GitVersion.Tool/5.6.7)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
