### PR TITLE
Automatic update of Microsoft.NET.Test.Sdk to 16.9.4

### DIFF
--- a/SharpBoard.Tests/SharpBoard.Tests.csproj
+++ b/SharpBoard.Tests/SharpBoard.Tests.csproj
@@ -12,7 +12,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
NuKeeper has generated a patch update of `Microsoft.NET.Test.Sdk` to `16.9.4` from `16.9.1`
`Microsoft.NET.Test.Sdk 16.9.4` was published at `2021-04-01T10:13:33Z`, 19 hours ago

1 project update:
Updated `SharpBoard.Tests\SharpBoard.Tests.csproj` to `Microsoft.NET.Test.Sdk` `16.9.4` from `16.9.1`

[Microsoft.NET.Test.Sdk 16.9.4 on NuGet.org](https://www.nuget.org/packages/Microsoft.NET.Test.Sdk/16.9.4)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
