### PR TITLE
Automatic update of GitVersion.Tool to 5.6.8

### DIFF
--- a/SharpBoard.Build/SharpBoard.Build.csproj
+++ b/SharpBoard.Build/SharpBoard.Build.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageDownload Include="dotnet-sonarscanner" Version="[5.1.0]" />
     <PackageDownload Include="dotnet-format" Version="[5.0.211103]" />
-    <PackageDownload Include="GitVersion.Tool" Version="[5.6.7]" />
+    <PackageDownload Include="GitVersion.Tool" Version="[5.6.8]" />
     <PackageDownload Include="nukeeper" Version="[0.34.0]" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
NuKeeper has generated a patch update of `GitVersion.Tool` to `5.6.8` from `5.6.7`
`GitVersion.Tool 5.6.8` was published at `2021-04-06T19:00:20Z`, 11 hours ago

1 project update:
Updated `SharpBoard.Build\SharpBoard.Build.csproj` to `GitVersion.Tool` `5.6.8` from `5.6.7`

[GitVersion.Tool 5.6.8 on NuGet.org](https://www.nuget.org/packages/GitVersion.Tool/5.6.8)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
