### PR TITLE
Automatic update of Nuke.Common to 5.1.0

### DIFF
--- a/SharpBoard.Build/SharpBoard.Build.csproj
+++ b/SharpBoard.Build/SharpBoard.Build.csproj
@@ -9,7 +9,7 @@
     <NukeScriptDirectory>..</NukeScriptDirectory>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Nuke.Common" Version="5.0.2" />
+    <PackageReference Include="Nuke.Common" Version="5.1.0" />
   </ItemGroup>
   <ItemGroup>
     <PackageDownload Include="dotnet-sonarscanner" Version="[5.1.0]" />


### PR DESCRIPTION
NuKeeper has generated a minor update of `Nuke.Common` to `5.1.0` from `5.0.2`
`Nuke.Common 5.1.0` was published at `2021-04-07T10:32:25Z`, 19 hours ago

1 project update:
Updated `SharpBoard.Build\SharpBoard.Build.csproj` to `Nuke.Common` `5.1.0` from `5.0.2`

[Nuke.Common 5.1.0 on NuGet.org](https://www.nuget.org/packages/Nuke.Common/5.1.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
