### PR TITLE
Automatic update of 3 packages

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,6 +6,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Roslynator.Analyzers" Version="3.1.0" PrivateAssets="all" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.20.0.28934" PrivateAssets="all" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.21.0.30542" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/SharpBoard.Build/SharpBoard.Build.csproj
+++ b/SharpBoard.Build/SharpBoard.Build.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Nuke.Common" Version="5.1.0" />
   </ItemGroup>
   <ItemGroup>
-    <PackageDownload Include="dotnet-sonarscanner" Version="[5.1.0]" />
+    <PackageDownload Include="dotnet-sonarscanner" Version="[5.2.0]" />
     <PackageDownload Include="dotnet-format" Version="[5.0.211103]" />
     <PackageDownload Include="GitVersion.Tool" Version="[5.6.8]" />
     <PackageDownload Include="nukeeper" Version="[0.34.0]" />

--- a/SharpBoard.Build/SharpBoard.Build.csproj
+++ b/SharpBoard.Build/SharpBoard.Build.csproj
@@ -9,7 +9,7 @@
     <NukeScriptDirectory>..</NukeScriptDirectory>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Nuke.Common" Version="5.0.2" />
+    <PackageReference Include="Nuke.Common" Version="5.1.0" />
   </ItemGroup>
   <ItemGroup>
     <PackageDownload Include="dotnet-sonarscanner" Version="[5.1.0]" />


### PR DESCRIPTION
3 packages were updated in 2 projects:
`Nuke.Common`, `dotnet-sonarscanner`, `SonarAnalyzer.CSharp`
<details>
<summary>Details of updated packages</summary>

NuKeeper has generated a minor update of `Nuke.Common` to `5.1.0` from `5.0.2`
`Nuke.Common 5.1.0` was published at `2021-04-07T10:32:25Z`, 12 days ago

1 project update:
Updated `SharpBoard.Build\SharpBoard.Build.csproj` to `Nuke.Common` `5.1.0` from `5.0.2`

[Nuke.Common 5.1.0 on NuGet.org](https://www.nuget.org/packages/Nuke.Common/5.1.0)

NuKeeper has generated a minor update of `dotnet-sonarscanner` to `5.2.0` from `5.1.0`
`dotnet-sonarscanner 5.2.0` was published at `2021-04-08T11:20:03Z`, 11 days ago

1 project update:
Updated `SharpBoard.Build\SharpBoard.Build.csproj` to `dotnet-sonarscanner` `5.2.0` from `5.1.0`

[dotnet-sonarscanner 5.2.0 on NuGet.org](https://www.nuget.org/packages/dotnet-sonarscanner/5.2.0)

NuKeeper has generated a minor update of `SonarAnalyzer.CSharp` to `8.21.0.30542` from `8.20.0.28934`
`SonarAnalyzer.CSharp 8.21.0.30542` was published at `2021-04-19T08:47:42Z`, 21 hours ago

1 project update:
Updated `Directory.Build.props` to `SonarAnalyzer.CSharp` `8.21.0.30542` from `8.20.0.28934`

[SonarAnalyzer.CSharp 8.21.0.30542 on NuGet.org](https://www.nuget.org/packages/SonarAnalyzer.CSharp/8.21.0.30542)

</details>


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
