### PR TITLE
Automatic update of 5 packages

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,6 +6,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Roslynator.Analyzers" Version="3.1.0" PrivateAssets="all" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.20.0.28934" PrivateAssets="all" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.22.0.31243" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/SharpBoard.Build/SharpBoard.Build.csproj
+++ b/SharpBoard.Build/SharpBoard.Build.csproj
@@ -9,7 +9,7 @@
     <NukeScriptDirectory>..</NukeScriptDirectory>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Nuke.Common" Version="5.0.2" />
+    <PackageReference Include="Nuke.Common" Version="5.1.1" />
   </ItemGroup>
   <ItemGroup>
     <PackageDownload Include="dotnet-sonarscanner" Version="[5.1.0]" />

--- a/SharpBoard.Build/SharpBoard.Build.csproj
+++ b/SharpBoard.Build/SharpBoard.Build.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageDownload Include="dotnet-sonarscanner" Version="[5.2.1]" />
     <PackageDownload Include="dotnet-format" Version="[5.1.225507]" />
-    <PackageDownload Include="GitVersion.Tool" Version="[5.6.8]" />
+    <PackageDownload Include="GitVersion.Tool" Version="[5.6.9]" />
     <PackageDownload Include="nukeeper" Version="[0.34.0]" />
   </ItemGroup>
 </Project>

--- a/SharpBoard.Build/SharpBoard.Build.csproj
+++ b/SharpBoard.Build/SharpBoard.Build.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Nuke.Common" Version="5.1.1" />
   </ItemGroup>
   <ItemGroup>
-    <PackageDownload Include="dotnet-sonarscanner" Version="[5.1.0]" />
+    <PackageDownload Include="dotnet-sonarscanner" Version="[5.2.1]" />
     <PackageDownload Include="dotnet-format" Version="[5.0.211103]" />
     <PackageDownload Include="GitVersion.Tool" Version="[5.6.8]" />
     <PackageDownload Include="nukeeper" Version="[0.34.0]" />

--- a/SharpBoard.Build/SharpBoard.Build.csproj
+++ b/SharpBoard.Build/SharpBoard.Build.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageDownload Include="dotnet-sonarscanner" Version="[5.2.1]" />
-    <PackageDownload Include="dotnet-format" Version="[5.0.211103]" />
+    <PackageDownload Include="dotnet-format" Version="[5.1.225507]" />
     <PackageDownload Include="GitVersion.Tool" Version="[5.6.8]" />
     <PackageDownload Include="nukeeper" Version="[0.34.0]" />
   </ItemGroup>


### PR DESCRIPTION
5 packages were updated in 2 projects:
`SonarAnalyzer.CSharp`, `Nuke.Common`, `dotnet-sonarscanner`, `dotnet-format`, `GitVersion.Tool`
<details>
<summary>Details of updated packages</summary>

NuKeeper has generated a minor update of `SonarAnalyzer.CSharp` to `8.22.0.31243` from `8.20.0.28934`
`SonarAnalyzer.CSharp 8.22.0.31243` was published at `2021-04-29T15:58:15Z`, 6 days ago

1 project update:
Updated `Directory.Build.props` to `SonarAnalyzer.CSharp` `8.22.0.31243` from `8.20.0.28934`

[SonarAnalyzer.CSharp 8.22.0.31243 on NuGet.org](https://www.nuget.org/packages/SonarAnalyzer.CSharp/8.22.0.31243)

NuKeeper has generated a minor update of `Nuke.Common` to `5.1.1` from `5.0.2`
`Nuke.Common 5.1.1` was published at `2021-04-23T15:51:55Z`, 12 days ago

1 project update:
Updated `SharpBoard.Build\SharpBoard.Build.csproj` to `Nuke.Common` `5.1.1` from `5.0.2`

[Nuke.Common 5.1.1 on NuGet.org](https://www.nuget.org/packages/Nuke.Common/5.1.1)

NuKeeper has generated a minor update of `dotnet-sonarscanner` to `5.2.1` from `5.1.0`
`dotnet-sonarscanner 5.2.1` was published at `2021-04-29T12:51:58Z`, 6 days ago

1 project update:
Updated `SharpBoard.Build\SharpBoard.Build.csproj` to `dotnet-sonarscanner` `5.2.1` from `5.1.0`

[dotnet-sonarscanner 5.2.1 on NuGet.org](https://www.nuget.org/packages/dotnet-sonarscanner/5.2.1)

NuKeeper has generated a minor update of `dotnet-format` to `5.1.225507` from `5.0.211103`
`dotnet-format 5.1.225507` was published at `2021-05-05T18:47:14Z`, 11 hours ago

1 project update:
Updated `SharpBoard.Build\SharpBoard.Build.csproj` to `dotnet-format` `5.1.225507` from `5.0.211103`

[dotnet-format 5.1.225507 on NuGet.org](https://www.nuget.org/packages/dotnet-format/5.1.225507)

NuKeeper has generated a patch update of `GitVersion.Tool` to `5.6.9` from `5.6.8`
`GitVersion.Tool 5.6.9` was published at `2021-04-29T07:01:17Z`, 6 days ago

1 project update:
Updated `SharpBoard.Build\SharpBoard.Build.csproj` to `GitVersion.Tool` `5.6.9` from `5.6.8`

[GitVersion.Tool 5.6.9 on NuGet.org](https://www.nuget.org/packages/GitVersion.Tool/5.6.9)

</details>


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
